### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "rust-overlay": []
       },
       "locked": {
-        "lastModified": 1682985522,
-        "narHash": "sha256-QpaH83EEJ5t2eucsgcuhdgBnvhnm90D1jrCihAql508=",
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "841b3f7017556aa6ed040744f83472835a5bf98e",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682786779,
-        "narHash": "sha256-m7QFzPS/CE8hbkbIVK4UStihAQMtczr0vSpOgETOM1g=",
+        "lastModified": 1693663421,
+        "narHash": "sha256-ImMIlWE/idjcZAfxKK8sQA7A1Gi/O58u5/CJA+mxvl8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b",
+        "rev": "e56990880811a451abd32515698c712788be5720",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682993975,
-        "narHash": "sha256-LlI5vwUw97NLAwcOYHRLRfhICVdp7MK2KFcUSj0Zwdg=",
+        "lastModified": 1693793487,
+        "narHash": "sha256-MS6CDyAC0sJMTE/pRYlfrhBnhlAPvEo43ipwf5ZNzHg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "07f421299826591e2b28e03bbbe19a5292395afe",
+        "rev": "f179280eed5eb93759c94bf3231fbbda28f894b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/841b3f7017556aa6ed040744f83472835a5bf98e' (2023-05-01)
  → 'github:ipetkov/crane/8b4f7a4dab2120cf41e7957a28a853f45016bd9d' (2023-09-04)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/cfacdce06f30d2b68473a46042957675eebb3401' (2023-04-11)
  → 'github:numtide/flake-utils/f9e7cf818399d17d347f847525c5a5a8032e4e44' (2023-08-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b' (2023-04-29)
  → 'github:nixos/nixpkgs/e56990880811a451abd32515698c712788be5720' (2023-09-02)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/07f421299826591e2b28e03bbbe19a5292395afe' (2023-05-02)
  → 'github:oxalica/rust-overlay/f179280eed5eb93759c94bf3231fbbda28f894b7' (2023-09-04)

```

</p></details>

 - Updated input [`crane`](https://github.com/ipetkov/crane): [`841b3f70` ➡️ `8b4f7a4d`](https://github.com/ipetkov/crane/compare/841b3f7017556aa6ed040744f83472835a5bf98e...8b4f7a4dab2120cf41e7957a28a853f45016bd9d) <sub>(2023-05-01 to 2023-09-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`08e4dc3a` ➡️ `e5699088`](https://github.com/nixos/nixpkgs/compare/08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b...e56990880811a451abd32515698c712788be5720) <sub>(2023-04-29 to 2023-09-02)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`07f42129` ➡️ `f179280e`](https://github.com/oxalica/rust-overlay/compare/07f421299826591e2b28e03bbbe19a5292395afe...f179280eed5eb93759c94bf3231fbbda28f894b7) <sub>(2023-05-02 to 2023-09-04)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`cfacdce0` ➡️ `f9e7cf81`](https://github.com/numtide/flake-utils/compare/cfacdce06f30d2b68473a46042957675eebb3401...f9e7cf818399d17d347f847525c5a5a8032e4e44) <sub>(2023-04-11 to 2023-08-23)</sub>