### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694032533,
-        "narHash": "sha256-I8cfCV/4JNJJ8KHOTxTU1EphKT8ARSb4s9pq99prYV0=",
+        "lastModified": 1694593561,
+        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "efd23a1c9ae8c574e2ca923c2b2dc336797f4cc4",
+        "rev": "1697b7d480449b01111e352021f46e5879e47643",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693793487,
-        "narHash": "sha256-MS6CDyAC0sJMTE/pRYlfrhBnhlAPvEo43ipwf5ZNzHg=",
+        "lastModified": 1694657451,
+        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f179280eed5eb93759c94bf3231fbbda28f894b7",
+        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/f9e7cf818399d17d347f847525c5a5a8032e4e44' (2023-08-23)
  → 'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/efd23a1c9ae8c574e2ca923c2b2dc336797f4cc4' (2023-09-06)
  → 'github:nixos/nixpkgs/1697b7d480449b01111e352021f46e5879e47643' (2023-09-13)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/f179280eed5eb93759c94bf3231fbbda28f894b7' (2023-09-04)
  → 'github:oxalica/rust-overlay/7c4f46f0b3597e3c4663285e6794194e55574879' (2023-09-14)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`efd23a1c` ➡️ `1697b7d4`](https://github.com/nixos/nixpkgs/compare/efd23a1c9ae8c574e2ca923c2b2dc336797f4cc4...1697b7d480449b01111e352021f46e5879e47643) <sub>(2023-09-06 to 2023-09-13)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`f179280e` ➡️ `7c4f46f0`](https://github.com/oxalica/rust-overlay/compare/f179280eed5eb93759c94bf3231fbbda28f894b7...7c4f46f0b3597e3c4663285e6794194e55574879) <sub>(2023-09-04 to 2023-09-14)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`f9e7cf81` ➡️ `ff7b65b4`](https://github.com/numtide/flake-utils/compare/f9e7cf818399d17d347f847525c5a5a8032e4e44...ff7b65b44d01cf9ba6a71320833626af21126384) <sub>(2023-08-23 to 2023-09-12)</sub>