### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,16 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": [],
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": []
+        ]
       },
       "locked": {
-        "lastModified": 1693787605,
-        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "lastModified": 1698166613,
+        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
         "type": "github"
       },
       "original": {
@@ -45,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694593561,
-        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "lastModified": 1698553279,
+        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1697b7d480449b01111e352021f46e5879e47643",
+        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
         "type": "github"
       },
       "original": {
@@ -77,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694657451,
-        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
+        "lastModified": 1698726852,
+        "narHash": "sha256-V1S4TTzg++GzPc96i/yy4jib+7/xU0LXHcggm9MllMM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
+        "rev": "ec19bd20af08f3b004089cc12ab54c823ed899b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/8b4f7a4dab2120cf41e7957a28a853f45016bd9d' (2023-09-04)
  → 'github:ipetkov/crane/b7db46f0f1751f7b1d1911f6be7daf568ad5bc65' (2023-10-24)
• Removed input 'crane/flake-compat'
• Removed input 'crane/flake-utils'
• Removed input 'crane/rust-overlay'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1697b7d480449b01111e352021f46e5879e47643' (2023-09-13)
  → 'github:nixos/nixpkgs/90e85bc7c1a6fc0760a94ace129d3a1c61c3d035' (2023-10-29)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/7c4f46f0b3597e3c4663285e6794194e55574879' (2023-09-14)
  → 'github:oxalica/rust-overlay/ec19bd20af08f3b004089cc12ab54c823ed899b7' (2023-10-31)

```

</p></details>

 - Removed input `crane/flake-compat`.
 - Updated input [`crane`](https://github.com/ipetkov/crane): [`8b4f7a4d` ➡️ `b7db46f0`](https://github.com/ipetkov/crane/compare/8b4f7a4dab2120cf41e7957a28a853f45016bd9d...b7db46f0f1751f7b1d1911f6be7daf568ad5bc65) <sub>(2023-09-04 to 2023-10-24)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1697b7d4` ➡️ `90e85bc7`](https://github.com/nixos/nixpkgs/compare/1697b7d480449b01111e352021f46e5879e47643...90e85bc7c1a6fc0760a94ace129d3a1c61c3d035) <sub>(2023-09-13 to 2023-10-29)</sub>
 - Removed input `crane/flake-utils`.
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`7c4f46f0` ➡️ `ec19bd20`](https://github.com/oxalica/rust-overlay/compare/7c4f46f0b3597e3c4663285e6794194e55574879...ec19bd20af08f3b004089cc12ab54c823ed899b7) <sub>(2023-09-14 to 2023-10-31)</sub>
 - Removed input `crane/rust-overlay`.