### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,16 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": [],
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": []
+        ]
       },
       "locked": {
-        "lastModified": 1693787605,
-        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "lastModified": 1702488130,
+        "narHash": "sha256-Bz4KTuBARAQY8952CpmYVD9o/LoScYjdw8KrK2OjEoA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "rev": "33dbb6a8342e1cf6252c8976d02ff8a7632aa071",
         "type": "github"
       },
       "original": {
@@ -30,11 +25,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -45,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694593561,
-        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "lastModified": 1702272962,
+        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1697b7d480449b01111e352021f46e5879e47643",
+        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
         "type": "github"
       },
       "original": {
@@ -77,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694657451,
-        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
+        "lastModified": 1702520151,
+        "narHash": "sha256-jxJWosN7hgcW+dFT8V3EBDCYUOjv5tpjEBRmlakS7tU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
+        "rev": "d6a1d8f80dbcda4c13993b859a3574c3dde61072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/8b4f7a4dab2120cf41e7957a28a853f45016bd9d' (2023-09-04)
  → 'github:ipetkov/crane/33dbb6a8342e1cf6252c8976d02ff8a7632aa071' (2023-12-13)
• Removed input 'crane/flake-compat'
• Removed input 'crane/flake-utils'
• Removed input 'crane/rust-overlay'
• Updated input 'flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
  → 'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1697b7d480449b01111e352021f46e5879e47643' (2023-09-13)
  → 'github:nixos/nixpkgs/e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d' (2023-12-11)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/7c4f46f0b3597e3c4663285e6794194e55574879' (2023-09-14)
  → 'github:oxalica/rust-overlay/d6a1d8f80dbcda4c13993b859a3574c3dde61072' (2023-12-14)

```

</p></details>

 - Removed input `crane/flake-compat`.
 - Updated input [`crane`](https://github.com/ipetkov/crane): [`8b4f7a4d` ➡️ `33dbb6a8`](https://github.com/ipetkov/crane/compare/8b4f7a4dab2120cf41e7957a28a853f45016bd9d...33dbb6a8342e1cf6252c8976d02ff8a7632aa071) <sub>(2023-09-04 to 2023-12-13)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1697b7d4` ➡️ `e97b3e41`](https://github.com/nixos/nixpkgs/compare/1697b7d480449b01111e352021f46e5879e47643...e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d) <sub>(2023-09-13 to 2023-12-11)</sub>
 - Removed input `crane/flake-utils`.
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`7c4f46f0` ➡️ `d6a1d8f8`](https://github.com/oxalica/rust-overlay/compare/7c4f46f0b3597e3c4663285e6794194e55574879...d6a1d8f80dbcda4c13993b859a3574c3dde61072) <sub>(2023-09-14 to 2023-12-14)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`ff7b65b4` ➡️ `4022d587`](https://github.com/numtide/flake-utils/compare/ff7b65b44d01cf9ba6a71320833626af21126384...4022d587cbbfd70fe950c1e2083a02621806a725) <sub>(2023-09-12 to 2023-12-04)</sub>
 - Removed input `crane/rust-overlay`.