### PR TITLE
feat!: add all mode for worktrees

### DIFF
--- a/config.kdl
+++ b/config.kdl
@@ -44,12 +44,16 @@
 //
 // height 10
 
-// Select the repositories remote default branch if multiple worktrees are found. If the default
-// worktree cannot be found the fallback will be to select the correct one.
+// Specifies the handling of git worktrees. There are three available modes:
 //
-// Default: false
+// - 'ask':     Lists all worktrees and prompts the user for selection.
+// - 'default': For bare repositories, uses the worktree related to the default branch; for non-bare repositories
+//              uses the default working directory.
+// - 'all':     Opens a separate window for each worktree.
 //
-// default_worktree true
+// Default "ask"
+//
+// worktree "default"
 
 // Workspace directory crawler will prune the paths containing any of these components.
 // Options:

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -64,18 +64,22 @@ Default: `50%`
 height 10
 ----
 
-=== default_worktree
+=== worktree
 
-Select the repositories remote default branch if multiple worktrees are found. If the default
-worktree cannot be found the fallback will be to select the correct one.
+Specifies the handling of git worktrees. There are three available modes
+
+`ask`::     Lists all worktrees and prompts the user for selection.
+`default`:: For bare repositories, uses the worktree related to the default branch; for non-bare repositories
+            uses the default working directory.
+`all`::     Opens a separate window for each worktree.
 
 [%hardbreaks]
-Type: `boolean`
-Default: `false`
+Type: `string`
+Default: `ask`
 
 [source,javascript]
 ----
-default_worktree true
+worktree "ask"
 ----
 
 === exclude_paths

--- a/readme.adoc
+++ b/readme.adoc
@@ -199,18 +199,22 @@ Default: `50%`
 height 10
 ----
 
-=== default_worktree
+=== worktree
 
-Select the repositories remote default branch if multiple worktrees are found. If the default
-worktree cannot be found the fallback will be to select the correct one.
+Specifies the handling of git worktrees. There are three available modes
+
+`ask`::     Lists all worktrees and prompts the user for selection.
+`default`:: For bare repositories, uses the worktree related to the default branch; for non-bare repositories
+            uses the default working directory.
+`all`::     Opens a separate window for each worktree.
 
 [%hardbreaks]
-Type: `boolean`
-Default: `false`
+Type: `string`
+Default: `ask`
 
 [source,javascript]
 ----
-default_worktree true
+worktree "ask"
 ----
 
 === exclude_paths

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -100,6 +100,10 @@ pub struct Attach {
     #[arg(short, long, default_value_t = false)]
     pub default: bool,
 
+    /// Create mux window for each worktree
+    #[arg(short, long, default_value_t = false)]
+    pub all: bool,
+
     /// Exact path to either attach to existing session or create a new one if
     /// none exist
     #[arg(short, long, default_value = None)]

--- a/src/cmd/wcmd.rs
+++ b/src/cmd/wcmd.rs
@@ -23,7 +23,7 @@ impl Run for Wcmd {
         let target = format!("{}:{}", session_name.trim(), name);
 
         if !mux.session_exists(&target) {
-            mux.create_window(name)?;
+            mux.create_window(name, None)?;
         }
 
         let cmd: String = intersperse(self.cmds.iter().map(|f| f.as_str()), " ").collect();

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -96,6 +96,35 @@ pub enum ParseError {
         #[label("expected a percentage from 1-100%")] SourceSpan,
     ),
 
+    #[error("Invalid worktree mode")]
+    #[diagnostic(
+        code("tm::invalid_worktree_mode"),
+        help("possible values ['all', 'deafult', 'ask']")
+    )]
+    InvalidWorktreeMode(
+        #[source_code] Source,
+        #[label("unknown worktree mode")] SourceSpan,
+    ),
+
+    #[error("Unknown configuration option")]
+    #[diagnostic(code("tm::unknown_configuration_option"))]
+    UnknownConfigurationOption(
+        /// Name of unknown option
+        String,
+        #[source_code] Source,
+        #[label("Unknown option '{0}'")] SourceSpan,
+    ),
+
+    #[error("Deprecated option 'worktree'")]
+    #[diagnostic(
+        code("tm::deprecated_default_worktree"),
+        help("Replaced with 'worktree'")
+    )]
+    DeprecatedDefaultWorktree(
+        #[source_code] Source,
+        #[label("Deprecated option 'default_worktree'")] SourceSpan,
+    ),
+
     #[error(transparent)]
     #[diagnostic(transparent)]
     Kdl(#[from] KdlError),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,7 +34,7 @@ pub struct Config {
     pub exclude_path: IndexSet<String>,
     pub depth: usize,
     pub mode: Mode,
-    pub default_worktree: bool,
+    pub worktree_mode: WorktreeMode,
     pub mux: Mux,
 }
 
@@ -54,10 +54,18 @@ impl Default for Config {
             exclude_path: indexset! { "node_modules".to_string(), ".direnv".to_string(), ".cache".to_string(), ".local".to_string()},
             depth: 5,
             mode: Mode::default(),
-            default_worktree: false,
+            worktree_mode: WorktreeMode::default(),
             mux: Mux::default(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeMode {
+    All,
+    Default,
+    #[default]
+    Ask,
 }
 
 impl Config {

--- a/src/mux/mod.rs
+++ b/src/mux/mod.rs
@@ -36,8 +36,8 @@ impl Mux {
         tmux::kill_session(name)
     }
 
-    pub fn create_window(&self, name: &str) -> Result<()> {
-        tmux::create_window(name)
+    pub fn create_window(&self, name: &str, path: Option<&Path>) -> Result<()> {
+        tmux::create_window(name, path)
     }
 
     pub fn send_command(&self, name: &str, command: &str) -> Result<()> {

--- a/src/mux/tmux.rs
+++ b/src/mux/tmux.rs
@@ -55,10 +55,14 @@ pub fn kill_session(name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn create_window(name: &str) -> Result<()> {
-    Tmux::with_command(NewWindow::new().window_name(name))
-        .output()
-        .into_diagnostic()?;
+pub fn create_window(name: &str, path: Option<&Path>) -> Result<()> {
+    let window = match path {
+        Some(path) => NewWindow::new()
+            .window_name(name)
+            .start_directory(path.to_string_lossy()),
+        None => NewWindow::new().window_name(name),
+    };
+    Tmux::with_command(window).output().into_diagnostic()?;
     Ok(())
 }
 


### PR DESCRIPTION
Added a new mode to handle how tuxmux handles worktrees. The new mode `all` will create a window foreach worktree found.

BREAKING CHANGE: default_worktree is replaced with workspace which is an option that takes a string listing the mode.