### PR TITLE
refactor!: rename tm bin name to tux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           RESULT="target-${{ matrix.target }}"
           mkdir $RESULT
-          cp target/${{ matrix.target }}/release/tm $RESULT
+          cp target/${{ matrix.target }}/release/tux $RESULT
           cp -r target/${{ matrix.target }}/man $RESULT
           cp -r target/${{ matrix.target }}/completions $RESULT
           tar czvf ${{ matrix.name }} $RESULT

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # Edit at https://www.toptal.com/developers/gitignore?templates=rust,vim,visualstudiocode,windows,macos,linux,direnv
 
 release/
-doc/tm.1
+doc/tux.1
 /readme.md
 
 ### direnv ###

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1.0.47"
 tmux_interface = "0.3.1"
 
 [[bin]]
-name = "tm"
+name = "tux"
 path = "src/main.rs"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ use std::{
     path,
 };
 
-const BIN_NAME: &str = "tm";
+const BIN_NAME: &str = "tux";
 
 include!("src/cmd/cli.rs");
 

--- a/config.kdl
+++ b/config.kdl
@@ -1,8 +1,8 @@
 // Configure the list of search paths used to search for valid workspaces.
-// Tm uses these valid workspaces as options to attach to.
+// Tux uses these valid workspaces as options to attach to.
 // paths {
   // Workspace paths are paths to recursivly search to find valid workspaces.
-  // Tm will recursivly search the workspace paths until the max depth is
+  // Tux will recursivly search the workspace paths until the max depth is
   // reached. To override the default workspace value set optional
   // `default=false`.
   //

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -7,7 +7,7 @@ Tuxmux uses https://kdl.dev[KDL] as its configuration language.
 [source,shell]
 ----
 mkdir -p ~/.config/tuxmux
-tm --default-config > ~/.config/tuxmux/config.kdl
+tux --default-config > ~/.config/tuxmux/config.kdl
 ----
 
 == File locations
@@ -100,12 +100,12 @@ exclude_paths default=false {
 
 === paths
 
-Configure the list of search paths used to search for valid workspaces.  Tm uses these valid workspaces as options to
+Configure the list of search paths used to search for valid workspaces.  Tux uses these valid workspaces as options to
 attach to.
 
 ==== paths.workspace
 
-Workspace paths are paths to recursivly search to find valid workspaces.  Tm will recursivly search the workspace paths
+Workspace paths are paths to recursivly search to find valid workspaces.  Tux will recursivly search the workspace paths
 until the max depth is reached. To override the default workspace value set optional `default=false`
 
 Optional arguments:

--- a/doc/jumplist.adoc
+++ b/doc/jumplist.adoc
@@ -1,6 +1,6 @@
 = Jumplist
 
-image:https://user-images.githubusercontent.com/2746374/278850962-a9119e50-3394-4660-aa6b-d57e96021464.gif[]
+image:https://private-user-images.githubusercontent.com/2746374/293401660-fcaf25f9-409f-40f8-a8e8-872655f07ffd.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDM4NzA4ODEsIm5iZiI6MTcwMzg3MDU4MSwicGF0aCI6Ii8yNzQ2Mzc0LzI5MzQwMTY2MC1mY2FmMjVmOS00MDlmLTQwZjgtYThlOC04NzI2NTVmMDdmZmQuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDIzMTIyOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMjlUMTcyMzAxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9N2M5NzRlODZlYTZjMDQ1NjgzMjdmYjcxOTM5NWIxYzg4ZDdhYjExZDBjNWY4YWRlOWU3YjJlMDNmMDEyMTc4ZiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.w2PtClvo-BBPwXCtbupenuxMg8Uo_PyF6UC3bWCwQKA[]
 
 :harpoon: https://github.com/ThePrimeagen/harpoon#-harpooning
 
@@ -28,13 +28,13 @@ typically be done by defining a set of sessions or targets within your applicati
 .shell
 ----
 # Appends the path argument to the jumplist
-tm jump --path ~/.config/nvim
+tux jump --path ~/.config/nvim
 
 # Append the current path to the jumplist
-tm jump --path .
+tux jump --path .
 
 # Open the jumplist in your $EDITOR
-tm jump --edit
+tux jump --edit
 ----
 
 Navigating with Keybindings::
@@ -46,10 +46,10 @@ single key combination.
 .~/.config/tmux.conf
 ----
 # Bind homerow keys to tuxmux jumplist indices
-bind-key -r J   run-shell "tm jump --index 1"
-bind-key -r K   run-shell "tm jump --index 2"
-bind-key -r L   run-shell "tm jump --index 3"
-bind-key -r '"' run-shell "tm jump --index 4"
+bind-key -r J   run-shell "tux jump --index 1"
+bind-key -r K   run-shell "tux jump --index 2"
+bind-key -r L   run-shell "tux jump --index 3"
+bind-key -r '"' run-shell "tux jump --index 4"
 ----
 
 Seamless Session Attachment::

--- a/doc/man.adoc
+++ b/doc/man.adoc
@@ -1,15 +1,15 @@
-= tm(1)
+= tux(1)
 
 == Name
 
-tm - Tmux session manager
+tux - Tmux session manager
 
 == Synopsis
 
-*tm* [_OPTIONS_] _<SEARCH_QUERY>_
-*tm* [_OPTIONS_] _<COMMAND>_ [_ARGS_]
-*tm* [_OPTIONS_] *--version*
-*tm* [_OPTIONS_] *--help*
+*tux* [_OPTIONS_] _<SEARCH_QUERY>_
+*tux* [_OPTIONS_] _<COMMAND>_ [_ARGS_]
+*tux* [_OPTIONS_] *--version*
+*tux* [_OPTIONS_] *--help*
 
 == Descriptions
 

--- a/doc/readme.adoc
+++ b/doc/readme.adoc
@@ -8,9 +8,9 @@ image:https://img.shields.io/crates/v/tuxmux[crates-io-badge, link="https://crat
 image:https://img.shields.io/badge/license-Apache2.0-blue.svg[license-badge, link="{apache}"]
 
 [sidebar]
-*_Tuxmux_ (_tm_)* is a session and window manager for tmux.
+*_Tuxmux_ (_tux_)* is a session and window manager for tmux.
 
-image:https://user-images.githubusercontent.com/2746374/278740504-aefc8d13-109c-49d9-95c1-f746a5b5b2c8.gif[]
+image:https://private-user-images.githubusercontent.com/2746374/293403109-26a7462f-8e97-4842-8fb0-6beeb7fe0244.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDM4NzE1NjQsIm5iZiI6MTcwMzg3MTI2NCwicGF0aCI6Ii8yNzQ2Mzc0LzI5MzQwMzEwOS0yNmE3NDYyZi04ZTk3LTQ4NDItOGZiMC02YmVlYjdmZTAyNDQuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDIzMTIyOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMjlUMTczNDI0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ODgzNDE0MGFkYjA3YzVlNmZiYzlkY2M2ODlkM2MwZWY2NjQ1MTE2YTYwMjA5ZWM3ZmY4MzMxZmE4YjY4ZDcwMiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.SO12CXuXTGtOZCStW2ootD48qKeS45QJ1_iE5_SC4cA[]
 
 == Features
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,16 +61,16 @@
 
           preFixup = ''
             installManPage target/man/*
-            installShellCompletion --bash target/completions/tm.bash
-            installShellCompletion --zsh target/completions/_tm
-            installShellCompletion --fish target/completions/tm.fish
+            installShellCompletion --bash target/completions/tux.bash
+            installShellCompletion --zsh target/completions/tux
+            installShellCompletion --fish target/completions/tux.fish
           '';
 
           meta = with pkgs.lib; {
             description = "Tmux utility for session and window management";
             homepage = "https://github.com/EdenEast/tuxmux";
             license = licenses.apsl20;
-            mainProgram = "tm";
+            mainProgram = "tux";
           };
         });
 
@@ -93,7 +93,7 @@
         apps = {
           tuxmux = flake-utils.lib.mkApp {
             dev = tuxmux;
-            name = "tm";
+            name = "tux";
           };
           default = apps.tuxmux;
         };

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-default_bin := "tm"
+default_bin := "tux"
 
 doc: markdown
 
@@ -12,11 +12,11 @@ readme:
 
 man:
   #!/usr/bin/env bash
-  rm -f ./doc/tm.1
+  rm -f ./doc/tux.1
   version=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "tuxmux")|.version')
   asciidoctor-reducer --output man.adoc ./doc/man.adoc
-  asciidoctor --attribute version="$version" --doctype manpage --backend manpage --out-file ./doc/tm.1 man.adoc
-  chmod 0444 ./doc/tm.1
+  asciidoctor --attribute version="$version" --doctype manpage --backend manpage --out-file ./doc/tux.1 man.adoc
+  chmod 0444 ./doc/tux.1
   rm man.adoc
 
 markdown: readme
@@ -33,13 +33,13 @@ markdown: readme
 
 release:
   #/usr/bin/env bash
-  cargo build --release --bin tm
+  cargo build --release --bin tux
   mkdir -p release/{completions,man}
   cp -f ./{LICENSE,readme.md} ./release
-  cp -f ./target/release/tm ./release
-  ./release/tm completions bash > ./release/completions/tm.bash
-  ./release/tm completions zsh > ./release/completions/_tm
-  ./release/tm completions fish > ./release/completions/tm.fish
-  ./release/tm completions powershell > ./release/completions/_tm.ps1
-  ./release/tm completions elvish > ./release/completions/tm.elv
-  pandoc --standalone --to man doc/tm.md -o release/man/tm.1
+  cp -f ./target/release/tux ./release
+  ./release/tux completions bash > ./release/completions/tux.bash
+  ./release/tux completions zsh > ./release/completions/tux
+  ./release/tux completions fish > ./release/completions/tux.fish
+  ./release/tux completions powershell > ./release/completions/tux.ps1
+  ./release/tux completions elvish > ./release/completions/tux.elv
+  pandoc --standalone --to man doc/tux.md -o release/man/tux.1

--- a/readme.adoc
+++ b/readme.adoc
@@ -9,9 +9,9 @@ image:https://img.shields.io/crates/v/tuxmux[crates-io-badge, link="https://crat
 image:https://img.shields.io/badge/license-Apache2.0-blue.svg[license-badge, link="{apache}"]
 
 [sidebar]
-*_Tuxmux_ (_tm_)* is a session and window manager for tmux.
+*_Tuxmux_ (_tux_)* is a session and window manager for tmux.
 
-image:https://user-images.githubusercontent.com/2746374/278740504-aefc8d13-109c-49d9-95c1-f746a5b5b2c8.gif[]
+image:https://private-user-images.githubusercontent.com/2746374/293403109-26a7462f-8e97-4842-8fb0-6beeb7fe0244.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDM4NzE1NjQsIm5iZiI6MTcwMzg3MTI2NCwicGF0aCI6Ii8yNzQ2Mzc0LzI5MzQwMzEwOS0yNmE3NDYyZi04ZTk3LTQ4NDItOGZiMC02YmVlYjdmZTAyNDQuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDIzMTIyOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMjlUMTczNDI0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ODgzNDE0MGFkYjA3YzVlNmZiYzlkY2M2ODlkM2MwZWY2NjQ1MTE2YTYwMjA5ZWM3ZmY4MzMxZmE4YjY4ZDcwMiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.SO12CXuXTGtOZCStW2ootD48qKeS45QJ1_iE5_SC4cA[]
 
 == Features
 
@@ -61,7 +61,7 @@ cargo install --path .
 
 = Jumplist
 
-image:https://user-images.githubusercontent.com/2746374/278850962-a9119e50-3394-4660-aa6b-d57e96021464.gif[]
+image:https://private-user-images.githubusercontent.com/2746374/293401660-fcaf25f9-409f-40f8-a8e8-872655f07ffd.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDM4NzA4ODEsIm5iZiI6MTcwMzg3MDU4MSwicGF0aCI6Ii8yNzQ2Mzc0LzI5MzQwMTY2MC1mY2FmMjVmOS00MDlmLTQwZjgtYThlOC04NzI2NTVmMDdmZmQuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDIzMTIyOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMjlUMTcyMzAxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9N2M5NzRlODZlYTZjMDQ1NjgzMjdmYjcxOTM5NWIxYzg4ZDdhYjExZDBjNWY4YWRlOWU3YjJlMDNmMDEyMTc4ZiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.w2PtClvo-BBPwXCtbupenuxMg8Uo_PyF6UC3bWCwQKA[]
 
 :harpoon: https://github.com/ThePrimeagen/harpoon#-harpooning
 
@@ -89,13 +89,13 @@ typically be done by defining a set of sessions or targets within your applicati
 .shell
 ----
 # Appends the path argument to the jumplist
-tm jump --path ~/.config/nvim
+tux jump --path ~/.config/nvim
 
 # Append the current path to the jumplist
-tm jump --path .
+tux jump --path .
 
 # Open the jumplist in your $EDITOR
-tm jump --edit
+tux jump --edit
 ----
 
 Navigating with Keybindings::
@@ -107,10 +107,10 @@ single key combination.
 .~/.config/tmux.conf
 ----
 # Bind homerow keys to tuxmux jumplist indices
-bind-key -r J   run-shell "tm jump --index 1"
-bind-key -r K   run-shell "tm jump --index 2"
-bind-key -r L   run-shell "tm jump --index 3"
-bind-key -r '"' run-shell "tm jump --index 4"
+bind-key -r J   run-shell "tux jump --index 1"
+bind-key -r K   run-shell "tux jump --index 2"
+bind-key -r L   run-shell "tux jump --index 3"
+bind-key -r '"' run-shell "tux jump --index 4"
 ----
 
 Seamless Session Attachment::
@@ -142,7 +142,7 @@ Tuxmux uses https://kdl.dev[KDL] as its configuration language.
 [source,shell]
 ----
 mkdir -p ~/.config/tuxmux
-tm --default-config > ~/.config/tuxmux/config.kdl
+tux --default-config > ~/.config/tuxmux/config.kdl
 ----
 
 == File locations
@@ -235,12 +235,12 @@ exclude_paths default=false {
 
 === paths
 
-Configure the list of search paths used to search for valid workspaces.  Tm uses these valid workspaces as options to
+Configure the list of search paths used to search for valid workspaces.  Tux uses these valid workspaces as options to
 attach to.
 
 ==== paths.workspace
 
-Workspace paths are paths to recursivly search to find valid workspaces.  Tm will recursivly search the workspace paths
+Workspace paths are paths to recursivly search to find valid workspaces.  Tux will recursivly search the workspace paths
 until the max depth is reached. To override the default workspace value set optional `default=false`
 
 Optional arguments:

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -14,7 +14,7 @@ command 'attach' will be assumed. \
 
 const JUMP_LONG_ABOUT: &str = "\
 Store a list of paths and jump to that index. This is useful for keybindings \
-where you set keybindingd to jump to index 1, 2, 3, ... and tm will check \
+where you set keybindingd to jump to index 1, 2, 3, ... and tux will check \
 the list of stored paths and use that to jump to that tmux session.
 
 By default if no options are passed then the cwd is added to the jump list \
@@ -37,14 +37,14 @@ have to be after '--'.
 
 const WCMD_EXAMPLE_AFTER_HELP: &str = "\
 EXAMPLES:
-  tm wcmd server cd backend
-  tm w foo/bar/baz -- make test
+  tux wcmd server cd backend
+  tux w foo/bar/baz -- make test
 ";
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "tm",
-    bin_name("tm"),
+    name = "tux",
+    bin_name("tux"),
     after_help = ARG_AFTER_HELP_MSG,
     about = crate_description!(),
     version = crate_version!(),
@@ -82,7 +82,7 @@ pub enum Cmd {
 #[derive(Debug, Args, Default)]
 #[command(
     visible_alias("a"),
-    bin_name("tm-attach"),
+    bin_name("tux-attach"),
     disable_colored_help(true),
     disable_version_flag(true)
 )]
@@ -116,7 +116,7 @@ pub struct Attach {
 #[derive(Debug, Args)]
 #[command(
     visible_alias("j"),
-    bin_name("tm-jump"),
+    bin_name("tux-jump"),
     disable_colored_help(true),
     disable_version_flag(true),
     long_about = JUMP_LONG_ABOUT,
@@ -143,7 +143,7 @@ pub struct Jump {
 #[derive(Debug, Args)]
 #[command(
     visible_alias("k"),
-    bin_name("tm-kill"),
+    bin_name("tux-kill"),
     disable_colored_help(true),
     disable_version_flag(true)
 )]
@@ -167,7 +167,7 @@ pub struct Kill {
 #[derive(Debug, Args)]
 #[command(
     visible_alias("ls"),
-    bin_name("tm-list"),
+    bin_name("tux-list"),
     disable_colored_help(true),
     disable_version_flag(true)
 )]
@@ -181,7 +181,7 @@ pub struct List {
 #[derive(Debug, Args)]
 #[command(
     visible_alias("w"),
-    bin_name("tm-wcmd"),
+    bin_name("tux-wcmd"),
     disable_colored_help(true),
     disable_version_flag(true),
     after_help = WCMD_EXAMPLE_AFTER_HELP,


### PR DESCRIPTION
This pr renames the binary name of tuxmux from `tm` to `tux`. This was made as tux is more memorable then `tm`.