### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -1,0 +1,1 @@
+dev-env-1-link

--- a/dev-env-1-link
+++ b/dev-env-1-link
@@ -1,0 +1,1 @@
+/nix/store/m6fgwgdnpw0jx13s72gn0bb2lzxjch30-tuxmux-env

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,16 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": [],
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": []
+        ]
       },
       "locked": {
-        "lastModified": 1693787605,
-        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "lastModified": 1710886643,
+        "narHash": "sha256-saTZuv9YeZ9COHPuj8oedGdUwJZcbQ3vyRqe7NVJMsQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "rev": "5bace74e9a65165c918205cf67ad3977fe79c584",
         "type": "github"
       },
       "original": {
@@ -30,11 +25,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -45,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694593561,
-        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "lastModified": 1711106783,
+        "narHash": "sha256-PDwAcHahc6hEimyrgGmFdft75gmLrJOZ0txX7lFqq+I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1697b7d480449b01111e352021f46e5879e47643",
+        "rev": "a3ed7406349a9335cb4c2a71369b697cecd9d351",
         "type": "github"
       },
       "original": {
@@ -77,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694657451,
-        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
+        "lastModified": 1711073443,
+        "narHash": "sha256-PpNb4xq7U5Q/DdX40qe7CijUsqhVVM3VZrhN0+c6Lcw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
+        "rev": "eec55ba9fcde6be4c63942827247e42afef7fafe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/8b4f7a4dab2120cf41e7957a28a853f45016bd9d' (2023-09-04)
  → 'github:ipetkov/crane/5bace74e9a65165c918205cf67ad3977fe79c584' (2024-03-19)
• Removed input 'crane/flake-compat'
• Removed input 'crane/flake-utils'
• Removed input 'crane/rust-overlay'
• Updated input 'flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1697b7d480449b01111e352021f46e5879e47643' (2023-09-13)
  → 'github:nixos/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351' (2024-03-22)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/7c4f46f0b3597e3c4663285e6794194e55574879' (2023-09-14)
  → 'github:oxalica/rust-overlay/eec55ba9fcde6be4c63942827247e42afef7fafe' (2024-03-22)

```

</p></details>

 - Removed input `crane/flake-compat`.
 - Updated input [`crane`](https://github.com/ipetkov/crane): [`8b4f7a4d` ➡️ `5bace74e`](https://github.com/ipetkov/crane/compare/8b4f7a4dab2120cf41e7957a28a853f45016bd9d...5bace74e9a65165c918205cf67ad3977fe79c584) <sub>(2023-09-04 to 2024-03-19)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1697b7d4` ➡️ `a3ed7406`](https://github.com/nixos/nixpkgs/compare/1697b7d480449b01111e352021f46e5879e47643...a3ed7406349a9335cb4c2a71369b697cecd9d351) <sub>(2023-09-13 to 2024-03-22)</sub>
 - Removed input `crane/flake-utils`.
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`7c4f46f0` ➡️ `eec55ba9`](https://github.com/oxalica/rust-overlay/compare/7c4f46f0b3597e3c4663285e6794194e55574879...eec55ba9fcde6be4c63942827247e42afef7fafe) <sub>(2023-09-14 to 2024-03-22)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`ff7b65b4` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/ff7b65b44d01cf9ba6a71320833626af21126384...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-09-12 to 2024-03-11)</sub>
 - Removed input `crane/rust-overlay`.