### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -1,0 +1,1 @@
+dev-env-1-link

--- a/dev-env-1-link
+++ b/dev-env-1-link
@@ -1,0 +1,1 @@
+/nix/store/5qbpjsnd145d567l0d073mx358gg1axj-tuxmux-env

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710886643,
-        "narHash": "sha256-saTZuv9YeZ9COHPuj8oedGdUwJZcbQ3vyRqe7NVJMsQ=",
+        "lastModified": 1717025063,
+        "narHash": "sha256-dIubLa56W9sNNz0e8jGxrX3CAkPXsq7snuFA/Ie6dn8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5bace74e9a65165c918205cf67ad3977fe79c584",
+        "rev": "480dff0be03dac0e51a8dfc26e882b0d123a450e",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711106783,
-        "narHash": "sha256-PDwAcHahc6hEimyrgGmFdft75gmLrJOZ0txX7lFqq+I=",
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3ed7406349a9335cb4c2a71369b697cecd9d351",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711073443,
-        "narHash": "sha256-PpNb4xq7U5Q/DdX40qe7CijUsqhVVM3VZrhN0+c6Lcw=",
+        "lastModified": 1717121863,
+        "narHash": "sha256-/3sxIe7MZqF/jw1RTQCSmgTjwVod43mmrk84m50MJQ4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eec55ba9fcde6be4c63942827247e42afef7fafe",
+        "rev": "2a7b53172ed08f856b8382d7dcfd36a4e0cbd866",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/5bace74e9a65165c918205cf67ad3977fe79c584' (2024-03-19)
  → 'github:ipetkov/crane/480dff0be03dac0e51a8dfc26e882b0d123a450e' (2024-05-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351' (2024-03-22)
  → 'github:nixos/nixpkgs/6132b0f6e344ce2fe34fc051b72fb46e34f668e0' (2024-05-30)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/eec55ba9fcde6be4c63942827247e42afef7fafe' (2024-03-22)
  → 'github:oxalica/rust-overlay/2a7b53172ed08f856b8382d7dcfd36a4e0cbd866' (2024-05-31)

```

</p></details>

 - Updated input [`crane`](https://github.com/ipetkov/crane): [`5bace74e` ➡️ `480dff0b`](https://github.com/ipetkov/crane/compare/5bace74e9a65165c918205cf67ad3977fe79c584...480dff0be03dac0e51a8dfc26e882b0d123a450e) <sub>(2024-03-19 to 2024-05-29)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a3ed7406` ➡️ `6132b0f6`](https://github.com/nixos/nixpkgs/compare/a3ed7406349a9335cb4c2a71369b697cecd9d351...6132b0f6e344ce2fe34fc051b72fb46e34f668e0) <sub>(2024-03-22 to 2024-05-30)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`eec55ba9` ➡️ `2a7b5317`](https://github.com/oxalica/rust-overlay/compare/eec55ba9fcde6be4c63942827247e42afef7fafe...2a7b53172ed08f856b8382d7dcfd36a4e0cbd866) <sub>(2024-03-22 to 2024-05-31)</sub>