### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -1,0 +1,1 @@
+dev-env-1-link

--- a/dev-env-1-link
+++ b/dev-env-1-link
@@ -1,0 +1,1 @@
+/nix/store/xf191qsxjq1fa72brm1nzn389chb3r2g-tuxmux-env

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1714536327,
-        "narHash": "sha256-zu4+LcygJwdyFHunTMeDFltBZ9+hoWvR/1A7IEy7ChA=",
+        "lastModified": 1725125250,
+        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3124551aebd8db15d4560716d4f903bd44c64e4a",
+        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
         "type": "github"
       },
       "original": {
@@ -38,31 +33,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717144377,
-        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
         "type": "github"
       },
       "original": {
@@ -82,17 +59,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1714616033,
-        "narHash": "sha256-JcWAjIDl3h0bE/pII0emeHwokTeBl+SWrzwrjoRu7a0=",
+        "lastModified": 1725157860,
+        "narHash": "sha256-DhqyM7XJYKj+WAEaYwMtXaYX66tA+lOd31sd5QkxLDM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3e416d5067ba31ff8ac31eeb763e4388bdf45089",
+        "rev": "1fd72e343c6890f695243a37b367a1e3b90a49ee",
         "type": "github"
       },
       "original": {
@@ -102,21 +78,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/3124551aebd8db15d4560716d4f903bd44c64e4a?narHash=sha256-zu4%2BLcygJwdyFHunTMeDFltBZ9%2BhoWvR/1A7IEy7ChA%3D' (2024-05-01)
  → 'github:ipetkov/crane/96fd12c7100e9e05fa1a0a5bd108525600ce282f?narHash=sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8%3D' (2024-08-31)
• Removed input 'crane/nixpkgs'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/805a384895c696f802a9bf5bf4720f37385df547?narHash=sha256-F/TKWETwB5RaR8owkPPi%2BSPJh83AQsm6KrQAlJ8v/uA%3D' (2024-05-31)
  → 'github:nixos/nixpkgs/6e99f2a27d600612004fbd2c3282d614bfee6421?narHash=sha256-eV%2B63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi%2BM%3D' (2024-08-30)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/3e416d5067ba31ff8ac31eeb763e4388bdf45089?narHash=sha256-JcWAjIDl3h0bE/pII0emeHwokTeBl%2BSWrzwrjoRu7a0%3D' (2024-05-02)
  → 'github:oxalica/rust-overlay/1fd72e343c6890f695243a37b367a1e3b90a49ee?narHash=sha256-DhqyM7XJYKj%2BWAEaYwMtXaYX66tA%2BlOd31sd5QkxLDM%3D' (2024-09-01)
• Removed input 'rust-overlay/flake-utils'
• Removed input 'rust-overlay/flake-utils/systems'

```

</p></details>

 - Updated input [`crane`](https://github.com/ipetkov/crane): [`3124551a` ➡️ `96fd12c7`](https://github.com/ipetkov/crane/compare/3124551aebd8db15d4560716d4f903bd44c64e4a...96fd12c7100e9e05fa1a0a5bd108525600ce282f) <sub>(2024-05-01 to 2024-08-31)</sub>
 - Removed input `rust-overlay/flake-utils`.
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`805a3848` ➡️ `6e99f2a2`](https://github.com/nixos/nixpkgs/compare/805a384895c696f802a9bf5bf4720f37385df547...6e99f2a27d600612004fbd2c3282d614bfee6421) <sub>(2024-05-31 to 2024-08-30)</sub>
 - Removed input `crane/nixpkgs`.
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`3e416d50` ➡️ `1fd72e34`](https://github.com/oxalica/rust-overlay/compare/3e416d5067ba31ff8ac31eeb763e4388bdf45089...1fd72e343c6890f695243a37b367a1e3b90a49ee) <sub>(2024-05-02 to 2024-09-01)</sub>
 - Removed input `rust-overlay/flake-utils/systems`.