### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -1,1 +1,1 @@
-dev-env-1-link
+dev-env-2-link

--- a/dev-env-2-link
+++ b/dev-env-2-link
@@ -1,0 +1,1 @@
+/nix/store/wrb8qk762dn8jdddh8wnfmnl7sbqp4f8-tuxmux-env

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1725409566,
+        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725001927,
-        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
+        "lastModified": 1726062281,
+        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
+        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725157860,
-        "narHash": "sha256-DhqyM7XJYKj+WAEaYwMtXaYX66tA+lOd31sd5QkxLDM=",
+        "lastModified": 1726280639,
+        "narHash": "sha256-YfLRPlFZWrT2oRLNAoqf7G3+NnUTDdlIJk6tmBU7kXM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1fd72e343c6890f695243a37b367a1e3b90a49ee",
+        "rev": "e9f8641c92f26fd1e076e705edb12147c384171d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/96fd12c7100e9e05fa1a0a5bd108525600ce282f?narHash=sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8%3D' (2024-08-31)
  → 'github:ipetkov/crane/7e4586bad4e3f8f97a9271def747cf58c4b68f3c?narHash=sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk%3D' (2024-09-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6e99f2a27d600612004fbd2c3282d614bfee6421?narHash=sha256-eV%2B63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi%2BM%3D' (2024-08-30)
  → 'github:nixos/nixpkgs/e65aa8301ba4f0ab8cb98f944c14aa9da07394f8?narHash=sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q%3D' (2024-09-11)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/1fd72e343c6890f695243a37b367a1e3b90a49ee?narHash=sha256-DhqyM7XJYKj%2BWAEaYwMtXaYX66tA%2BlOd31sd5QkxLDM%3D' (2024-09-01)
  → 'github:oxalica/rust-overlay/e9f8641c92f26fd1e076e705edb12147c384171d?narHash=sha256-YfLRPlFZWrT2oRLNAoqf7G3%2BNnUTDdlIJk6tmBU7kXM%3D' (2024-09-14)

```

</p></details>

 - Updated input [`crane`](https://github.com/ipetkov/crane): [`96fd12c7` ➡️ `7e4586ba`](https://github.com/ipetkov/crane/compare/96fd12c7100e9e05fa1a0a5bd108525600ce282f...7e4586bad4e3f8f97a9271def747cf58c4b68f3c) <sub>(2024-08-31 to 2024-09-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6e99f2a2` ➡️ `e65aa830`](https://github.com/nixos/nixpkgs/compare/6e99f2a27d600612004fbd2c3282d614bfee6421...e65aa8301ba4f0ab8cb98f944c14aa9da07394f8) <sub>(2024-08-30 to 2024-09-11)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`1fd72e34` ➡️ `e9f8641c`](https://github.com/oxalica/rust-overlay/compare/1fd72e343c6890f695243a37b367a1e3b90a49ee...e9f8641c92f26fd1e076e705edb12147c384171d) <sub>(2024-09-01 to 2024-09-14)</sub>