### PR TITLE
refactor: re-write to remove tmux_interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,12 +2156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tmux_interface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3885889703554d7b0dd515111432fc3b2f9cceb15b2139f9b12da73365299c05"
-
-[[package]]
 name = "tuxmux"
 version = "0.3.0-dev"
 dependencies = [
@@ -2181,7 +2175,6 @@ dependencies = [
  "rayon",
  "shellexpand",
  "thiserror 2.0.12",
- "tmux_interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ ratatui = "0.29.0"
 rayon = "1.10.0"
 shellexpand = "3.1.0"
 thiserror = "2.0.9"
-tmux_interface = "0.3.2"
 
 [[bin]]
 name = "tux"

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{cmd::cli::Attach, config::Config, ui::Picker, util, walker::Walker};
+use crate::{cmd::cli::Attach, config::Config, mux::Mux, ui::Picker, util, walker::Walker};
 
 use gix::{bstr::ByteSlice, Repository};
 use itertools::Itertools;
@@ -100,7 +100,7 @@ impl Attach {
         let repo = gix::open(selected).ok();
         let worktree = self.get_worktree(repo.as_ref(), config);
         let branch = repo.as_ref().and_then(head_branch);
-        mux.create_session(&name, selected.to_str().unwrap(), branch.as_deref())?;
+        mux.create_session(&name, selected, branch.as_deref())?;
 
         if let Some(worktree) = worktree {
             mux.send_command(&name, &format!("cd {}", worktree.display()))?;

--- a/src/cmd/jump.rs
+++ b/src/cmd/jump.rs
@@ -1,8 +1,8 @@
 use std::{env, path::Path};
 
-use miette::IntoDiagnostic;
+use miette::{miette, IntoDiagnostic};
 
-use crate::{cmd::cli::Jump, config::Config, jumplist::Jumplist};
+use crate::{cmd::cli::Jump, config::Config, jumplist::Jumplist, mux::Mux};
 
 use super::Run;
 
@@ -32,8 +32,18 @@ impl Run for Jump {
 
         if let Some(index) = self.index {
             if let Some(sel) = list.get(index.saturating_sub(1)) {
-                let name = Path::new(sel).file_name().unwrap().to_str().unwrap();
-                config.mux.create_or_attach(name, sel)?;
+                let path = Path::new(sel);
+                let name = path
+                    .file_name()
+                    .ok_or(miette!(
+                        "Failed to find the filename of path {}",
+                        path.display()
+                    ))?
+                    .to_str()
+                    .ok_or(miette!(
+                        "Failed to convert path's filename to a utf-8 string"
+                    ))?;
+                config.mux.create_or_attach(name, path)?;
             }
 
             return Ok(());

--- a/src/cmd/kill.rs
+++ b/src/cmd/kill.rs
@@ -1,4 +1,4 @@
-use crate::{cmd::cli::Kill, config::Config, ui::Picker};
+use crate::{cmd::cli::Kill, config::Config, mux::Mux, ui::Picker};
 
 use super::Run;
 

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,4 +1,4 @@
-use crate::{cmd::cli::List, config::Config, walker::Walker};
+use crate::{cmd::cli::List, config::Config, mux::Mux, walker::Walker};
 
 use super::Run;
 

--- a/src/cmd/wcmd.rs
+++ b/src/cmd/wcmd.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use miette::miette;
 
-use crate::{cmd::cli::Wcmd, config::Config, util::intersperse};
+use crate::{cmd::cli::Wcmd, config::Config, mux::Mux, util::intersperse};
 
 use super::Run;
 
@@ -23,7 +23,7 @@ impl Run for Wcmd {
         let target = format!("{}:{}", session_name.trim(), name);
 
         if !mux.session_exists(&target) {
-            mux.create_window(name)?;
+            mux.create_window(name, None)?;
         }
 
         let cmd: String = intersperse(self.cmds.iter().map(|f| f.as_str()), " ").collect();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-use crate::{mux::Mux, util};
+use crate::{mux::tmux::Tmux, util};
 use indexmap::{indexset, IndexSet};
 
 mod error;
@@ -28,15 +28,16 @@ impl Default for Mode {
     }
 }
 
-#[derive(Debug)]
 pub struct Config {
     pub search: SearchPath,
     pub exclude_path: IndexSet<String>,
     pub depth: usize,
     pub mode: Mode,
     pub default_worktree: bool,
-    pub mux: Mux,
+    pub mux: Tmux,
 }
+
+impl Config {}
 
 impl Default for SearchPath {
     fn default() -> Self {
@@ -55,7 +56,7 @@ impl Default for Config {
             depth: 5,
             mode: Mode::default(),
             default_worktree: false,
-            mux: Mux::default(),
+            mux: Tmux::default(),
         }
     }
 }

--- a/src/mux/mod.rs
+++ b/src/mux/mod.rs
@@ -1,59 +1,39 @@
 use std::path::Path;
 
-use miette::Result;
+use miette::{miette, Result};
 
-mod tmux;
+pub mod tmux;
 
-#[derive(Debug, Default)]
-pub enum Mux {
-    #[default]
-    Tmux,
+pub trait OutputExtension {
+    fn output_to_string(self) -> String;
+    fn to_result(self) -> Result<()>;
 }
 
-impl Mux {
-    pub fn list_sessions(&self) -> Vec<String> {
-        tmux::list_sessions()
+impl OutputExtension for std::process::Output {
+    fn output_to_string(self) -> String {
+        String::from_utf8(self.stdout)
+            .expect("The output of a `tmux` command should always be valid utf-8")
     }
 
-    pub fn session_exists(&self, name: &str) -> bool {
-        tmux::session_exists(name)
-    }
-
-    pub fn create_session<P: AsRef<Path>>(
-        &self,
-        name: &str,
-        path: P,
-        window_name: Option<&str>,
-    ) -> Result<()> {
-        tmux::create_session(name, path.as_ref(), window_name)
-    }
-
-    pub fn attach_session(&self, name: &str) -> Result<()> {
-        tmux::attach_session(name)
-    }
-
-    pub fn kill_session(&self, name: &str) -> Result<()> {
-        tmux::kill_session(name)
-    }
-
-    pub fn create_window(&self, name: &str) -> Result<()> {
-        tmux::create_window(name)
-    }
-
-    pub fn send_command(&self, name: &str, command: &str) -> Result<()> {
-        tmux::send_command(name, command)
-    }
-
-    pub fn session_name(&self) -> Option<String> {
-        tmux::session_name()
-    }
-
-    pub fn create_or_attach<P: AsRef<Path>>(&self, name: &str, path: P) -> Result<()> {
-        if self.session_exists(name) {
-            self.attach_session(name)
-        } else {
-            self.create_session(name, path.as_ref(), None)?;
-            self.attach_session(name)
+    fn to_result(self) -> Result<()> {
+        if self.status.success() {
+            return Ok(());
         }
+        Err(miette!(
+            "failed with {}",
+            String::from_utf8(self.stderr).expect("tmux stderr is not valid utf-8")
+        ))
     }
+}
+
+pub trait Mux: Sized {
+    fn list_sessions(&self) -> Vec<String>;
+    fn session_exists(&self, name: &str) -> bool;
+    fn create_session(&self, name: &str, path: &Path, window_name: Option<&str>) -> Result<()>;
+    fn attach_session(&self, name: &str) -> Result<()>;
+    fn kill_session(&self, name: &str) -> Result<()>;
+    fn create_window(&self, name: &str, path: Option<&Path>) -> Result<()>;
+    fn send_command(&self, name: &str, command: &str) -> Result<()>;
+    fn session_name(&self) -> Option<String>;
+    fn create_or_attach(&self, name: &str, path: &Path) -> Result<()>;
 }

--- a/src/mux/tmux.rs
+++ b/src/mux/tmux.rs
@@ -1,85 +1,114 @@
-use std::{borrow::Cow, path::Path};
+use std::path::Path;
+use std::process;
 
 use itertools::Itertools;
-use miette::{IntoDiagnostic, Result};
-use tmux_interface::{
-    AttachSession, DisplayMessage, HasSession, KillSession, ListSessions, NewSession, NewWindow,
-    SendKeys, SwitchClient, Tmux,
-};
 
-pub fn list_sessions() -> Vec<String> {
-    let output = match Tmux::with_command(ListSessions::new().format("#S")).output() {
-        Ok(o) => o,
-        Err(_) => return Vec::new(),
-    };
+use super::Mux;
+use super::OutputExtension;
 
-    String::from_utf8(output.stdout())
-        .map(|s| s.lines().map(|s| s.to_string()).collect_vec())
-        .unwrap_or_default()
+#[derive(Clone, Debug)]
+pub struct Tmux {
+    socket_name: String,
 }
 
-pub fn session_exists(name: &str) -> bool {
-    Tmux::with_command(HasSession::new().target_session(name))
-        .output()
-        .map(|out| out.success())
-        .unwrap_or(false)
-}
-
-pub fn create_session(name: &str, path: &Path, window_name: Option<&str>) -> Result<()> {
-    let mut command = NewSession::new()
-        .detached()
-        .session_name(name)
-        .start_directory(path.to_string_lossy());
-    command.window_name = window_name.map(Cow::Borrowed);
-    Tmux::with_command(command).output().into_diagnostic()?;
-    Ok(())
-}
-
-pub fn attach_session(name: &str) -> Result<()> {
-    if in_tmux() {
-        Tmux::with_command(SwitchClient::new().target_session(name))
-            .output()
-            .into_diagnostic()?;
-    } else {
-        Tmux::with_command(AttachSession::new().target_session(name))
-            .output()
-            .into_diagnostic()?;
+impl Default for Tmux {
+    fn default() -> Self {
+        let socket_name = std::env::var("TMS_TMUX_SOCKET")
+            .ok()
+            .unwrap_or("default".to_string());
+        Self { socket_name }
     }
-    Ok(())
 }
 
-pub fn kill_session(name: &str) -> Result<()> {
-    Tmux::with_command(KillSession::new().target_session(name))
-        .output()
-        .into_diagnostic()?;
-    Ok(())
+impl Tmux {
+    fn execute_tmux_command(&self, args: &[&str]) -> process::Output {
+        process::Command::new("tmux")
+            .args(["-L", &self.socket_name])
+            .args(args)
+            .stdin(process::Stdio::inherit())
+            .output()
+            .unwrap_or_else(|_| panic!("Failed to execute tmux command `{args:?}`"))
+    }
 }
 
-pub fn create_window(name: &str) -> Result<()> {
-    Tmux::with_command(NewWindow::new().window_name(name))
-        .output()
-        .into_diagnostic()?;
-    Ok(())
-}
+impl Mux for Tmux {
+    fn list_sessions(&self) -> Vec<String> {
+        self.execute_tmux_command(&["list-sessions", "-F", "#S"])
+            .output_to_string()
+            .split('\n')
+            .map(|x| x.to_string())
+            .collect_vec()
+    }
 
-pub fn send_command(name: &str, command: &str) -> Result<()> {
-    Tmux::with_command(SendKeys::new().target_pane(name).key(command))
-        .output()
-        .into_diagnostic()?;
-    Tmux::with_command(SendKeys::new().target_pane(name).key("C-m"))
-        .output()
-        .into_diagnostic()?;
-    Ok(())
-}
+    fn session_exists(&self, name: &str) -> bool {
+        self.execute_tmux_command(&["has-session", "-t", name])
+            .status
+            .success()
+    }
 
-pub fn session_name() -> Option<String> {
-    Tmux::with_command(DisplayMessage::new().print().message("#S"))
-        .output()
-        .into_diagnostic()
-        .and_then(|out| String::from_utf8(out.stdout()).into_diagnostic())
-        .ok()
-}
+    fn create_session(
+        &self,
+        name: &str,
+        path: &Path,
+        window_name: Option<&str>,
+    ) -> miette::Result<()> {
+        let mut args = vec![
+            "new-session",
+            "-d",
+            "-s",
+            name,
+            "-c",
+            path.to_str().expect("Path should be a utf-8 string"),
+        ];
 
-fn in_tmux() -> bool {
-    std::env::var("TMUX").is_ok()
+        if let Some(window_name) = window_name {
+            args.extend(["-n", window_name]);
+        }
+
+        self.execute_tmux_command(&args).to_result()
+    }
+
+    fn attach_session(&self, name: &str) -> miette::Result<()> {
+        self.execute_tmux_command(&["attach-session", "-t", name])
+            .to_result()
+    }
+
+    fn kill_session(&self, name: &str) -> miette::Result<()> {
+        self.execute_tmux_command(&["kill_session", "-t", name])
+            .to_result()
+    }
+
+    fn create_window(&self, name: &str, path: Option<&Path>) -> miette::Result<()> {
+        let mut args = vec!["new-window", "-n", name];
+
+        if let Some(path) = path {
+            args.extend(&["-c", path.to_str().expect("Path should be a utf-8 string")]);
+        }
+
+        self.execute_tmux_command(&args).to_result()
+    }
+
+    fn send_command(&self, name: &str, command: &str) -> miette::Result<()> {
+        self.execute_tmux_command(&["send-keys", "-t", name, command, "Enter"])
+            .to_result()
+    }
+
+    fn session_name(&self) -> Option<String> {
+        let output = self.execute_tmux_command(&["display-message", "-p", "#S"]);
+
+        if output.status.success() {
+            Some(output.output_to_string())
+        } else {
+            None
+        }
+    }
+
+    fn create_or_attach(&self, name: &str, path: &Path) -> miette::Result<()> {
+        if self.session_exists(name) {
+            self.attach_session(name)
+        } else {
+            self.create_session(name, path, None)?;
+            self.attach_session(name)
+        }
+    }
 }


### PR DESCRIPTION
When attaching to existing sessions tmux would disconnect when you type the first character into the terminal. This was not an issue when calling the tmux command line process directly. This is a re-write of the interface to use the builtin std::process::Command directly.